### PR TITLE
extended createFile to allow passing of field to be populated on upload

### DIFF
--- a/sharepointplus-3.12.js
+++ b/sharepointplus-3.12.js
@@ -203,7 +203,11 @@ if (typeof jQuery === "function") {
         var body="<soap:Envelope xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:soap='http://schemas.xmlsoap.org/soap/envelope/'><soap:Body><WebUrlFromPageUrl xmlns='http://schemas.microsoft.com/sharepoint/soap/' >"
                 +"<pageUrl>"+window.location.href.replace(/&/g,"&amp;")+"</pageUrl></WebUrlFromPageUrl></soap:Body></soap:Envelope>";
         var url = window.location.protocol + "//" + window.location.host + "/_vti_bin/Webs.asmx";
+        // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+        $.support.cors = true;
         jQuery.ajax({
+          // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+          crossDomain: true,
           type: "POST",
           cache: false,
           async: true,
@@ -1015,7 +1019,12 @@ if (typeof jQuery === "function") {
               + "</soap:Envelope>";
         // do the request
         var url = this.url + "/_vti_bin/Lists.asmx";
-        jQuery.ajax({type: "POST",
+        // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+        $.support.cors = true;
+        jQuery.ajax({
+                     // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                     crossDomain: true,
+                     type: "POST",
                      cache: false,
                      async: true,
                      url: url,
@@ -1208,7 +1217,9 @@ if (typeof jQuery === "function") {
                 + "</soap:Envelope>";
         // do the request
         var url = setup.url + "/_vti_bin/dspsts.asmx";
-        jQuery.ajax({type: "POST",
+        jQuery
+        .ajax({crossD
+        omain: true,type: "POST",
                      cache: false,
                      async: true,
                      url: url,
@@ -1338,6 +1349,24 @@ if (typeof jQuery === "function") {
 
       */
 
+      /* PolyFill for IE 8 */
+
+      if (!Object.keys) {
+        Object.keys = function(obj) {
+          var keys = [];
+
+          for (var i in obj) {
+            if (obj.hasOwnProperty(i)) {
+              keys.push(i);
+            }
+          }
+
+          return keys;
+        };
+      }
+
+      /* Polyfill end */
+
       if(setup.extraFields != undefined){
         var fields = '';
         for(i=0; i< setup.extraFields.length; i++){
@@ -1370,7 +1399,11 @@ if (typeof jQuery === "function") {
                     +"</CopyIntoItems>"
                     +"</soap:Body>"
                     +"</soap:Envelope>";
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
       jQuery.ajax({
+        // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+        crossDomain: true,
         url: setup.url + "/_vti_bin/copy.asmx",
         type: "POST",
         dataType: "xml",
@@ -1485,7 +1518,11 @@ if (typeof jQuery === "function") {
       + '<comment>'+setup.comments+'</comment>'
       + '<CheckinType>1</CheckinType></CheckInFile></soap:Body></soap:Envelope>';
 
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
       jQuery.ajax({
+        // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+        crossDomain: true,
         url: setup.url + "/_vti_bin/Lists.asmx",
         type: "POST",
         dataType: "xml",
@@ -1545,7 +1582,12 @@ if (typeof jQuery === "function") {
       var _this=this;
       var url = this.url + "/_vti_bin/lists.asmx";
       var aReturn = [];
-      jQuery.ajax({type: "POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type: "POST",
                    cache: false,
                    async: true,
                    url: url,
@@ -1618,7 +1660,12 @@ if (typeof jQuery === "function") {
       var _this=this;
       var url = this.url + "/_vti_bin/lists.asmx";
       var aReturn = [];
-      jQuery.ajax({type: "POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type: "POST",
                    cache: false,
                    async: true,
                    url: url,
@@ -1720,7 +1767,12 @@ if (typeof jQuery === "function") {
       var _this=this;
       var url = this.url + "/_vti_bin/lists.asmx";
       var aReturn = [];
-      jQuery.ajax({type: "POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type: "POST",
                    cache: false,
                    async: true,
                    url: url,
@@ -1820,7 +1872,12 @@ if (typeof jQuery === "function") {
       var _this=this;
       var url = this.url + "/_vti_bin/lists.asmx";
       var aReturn = [];
-      jQuery.ajax({type: "POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type: "POST",
                    cache: false,
                    async: true,
                    url: url,
@@ -1949,7 +2006,12 @@ if (typeof jQuery === "function") {
       var url = this.url + "/_vti_bin/Views.asmx";
       var aReturn = ["fields","orderby","whereCAML"];
       var _this=this;
-      jQuery.ajax({type: "POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type: "POST",
                    cache: false,
                    async: true,
                    url: url,
@@ -2040,7 +2102,12 @@ if (typeof jQuery === "function") {
       var url = this.url + "/_vti_bin/Views.asmx";
       var aReturn = [];
       var _this=this;
-      jQuery.ajax({type: "POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type: "POST",
                    cache: false,
                    async: true,
                    url: url,
@@ -2123,7 +2190,12 @@ if (typeof jQuery === "function") {
       var url = this.url + "/_vti_bin/lists.asmx";
       var aReturn = [];
       var _this=this;
-      jQuery.ajax({type:"POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type:"POST",
                    cache:false,
                    async:true,
                    url:url,
@@ -2262,7 +2334,12 @@ if (typeof jQuery === "function") {
       // send the request
       var url = this.url + "/_vti_bin/lists.asmx";
       var _this=this;     
-      jQuery.ajax({type:"POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type:"POST",
                    cache:false,
                    async:true,
                    url:url,
@@ -2424,7 +2501,12 @@ if (typeof jQuery === "function") {
       // send the request
       var url = this.url + "/_vti_bin/lists.asmx";
       var _this=this;
-      jQuery.ajax({type:"POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type:"POST",
                    cache:false,
                    async:true,
                    url:url,
@@ -2499,7 +2581,12 @@ if (typeof jQuery === "function") {
       // send the request
       var url = this.url + "/_vti_bin/lists.asmx";
       var _this=this;
-      jQuery.ajax({type:"POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type:"POST",
                    cache:false,
                    async:true,
                    url:url,
@@ -2629,7 +2716,12 @@ if (typeof jQuery === "function") {
       // send the request
       var url = this.url + "/_vti_bin/lists.asmx";
       var _this=this;
-      jQuery.ajax({type:"POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type:"POST",
                    cache:false,
                    async:true,
                    url:url,
@@ -2793,7 +2885,12 @@ if (typeof jQuery === "function") {
       // send the request
       var _this=this;
       var url = this.url + "/_vti_bin/lists.asmx";
-      jQuery.ajax({type:"POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type:"POST",
                    cache:false,
                    async:true,
                    url:url,
@@ -2887,7 +2984,12 @@ if (typeof jQuery === "function") {
       // send the request
       var _this=this;
       var url = setup.url + "/_vti_bin/usergroup.asmx";
-      jQuery.ajax({type:"POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type:"POST",
                    cache:false,
                    url:url,
                    data:body,
@@ -2980,7 +3082,11 @@ if (typeof jQuery === "function") {
                + '<item>'+fileRef+'</item>'
                + '</GetWorkflowDataForItem></soap:Body></soap:Envelope>';
               var _this=this;
+              // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+              $.support.cors = true;
               jQuery.ajax({
+                // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                crossDomain: true,
                 type: "POST",
                 cache: false,
                 async: true,
@@ -3150,7 +3256,11 @@ if (typeof jQuery === "function") {
         // do the request
         var _this=this;
         var url = this.url + "/_vti_bin/Workflow.asmx";
+        // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+        $.support.cors = true;
         jQuery.ajax({
+          // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+          crossDomain: true,
           type: "POST",
           cache: false,
           async: true,
@@ -3226,7 +3336,12 @@ if (typeof jQuery === "function") {
       // send the request
       var _this=this;
       var url = setup.url + "/_vti_bin/UserProfileService.asmx";
-      jQuery.ajax({type:"POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type:"POST",
                    cache:false,
                    url:url,
                    data:body,
@@ -3314,7 +3429,12 @@ if (typeof jQuery === "function") {
       // send the request
       var _this=this;
       var url = setup.url + "/_vti_bin/usergroup.asmx";
-      jQuery.ajax({type:"POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type:"POST",
                    cache:false,
                    url:url,
                    data:body,
@@ -3444,7 +3564,12 @@ if (typeof jQuery === "function") {
       // send the request
       var _this=this;
       var url = setup.url + "/_vti_bin/UserProfileService.asmx";
-      jQuery.ajax({type:"POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type:"POST",
                    cache:false,
                    url:url,
                    data:body,
@@ -3516,7 +3641,12 @@ if (typeof jQuery === "function") {
       // send the request
       var _this=this;
       var url = setup.url + "/_vti_bin/usergroup.asmx";
-      jQuery.ajax({type:"POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type:"POST",
                    cache:false,
                    url:url,
                    data:body,
@@ -3606,7 +3736,12 @@ if (typeof jQuery === "function") {
       // send the request
       var _this=this;
       var url = setup.url + "/_vti_bin/People.asmx";
-      jQuery.ajax({type: "POST",
+      // $.support.cors = true; - allows CORS in IE 8 to CORS enabled servers
+      $.support.cors = true;
+      jQuery.ajax({
+                   // crossDomain:true - allows CORS in IE 8 to CORS enabled servers
+                   crossDomain: true,
+                   type: "POST",
                    cache:false,
                    url:url,
                    data:body,


### PR DESCRIPTION
Expanded the createFile function to allow the ability to populate fields on file upload. Example of new functionality:

```
$SP().createFile({
    content:"*your stuff with FileToDataURI that returns a base64 string*",
    encoded:true,
    destination:"http://mysite/Shared Documents/myfile.xls",
    extraFields: [{Title:{value:"Hello world",type:"Text"}}],
    url:"http://mysite/"
});
 ```
`Title` is the name of the column you want to populate
`value` is the data to populate the field
`type` child can be one of the following options:

- Invalid
- Integer
- Text
- Note
- DateTime
- Counter
- Choice
- Lookup
- Boolean
- Number
- Currency
- URL
- Computed
- Threading
- Guid
- MultiChoice
- GridChoice
- Calculated
- File
- Attachments
- User
- Recurrence
- CrossProjectLink
- ModStat
- AllDayEvent
- Error

You can fill multiple columns by something like:

```
$SP().createFile({
    content:"*your stuff with FileToDataURI that returns a base64 string*",
    encoded:true,
    destination:"http://mysite/Shared Documents/myfile.xls",
    extraFields: [{Title:{value:"Hello world",type:"Text"}},{Title2:{value:"Hello world Again",type:"Text"}}],
    url:"http://mysite/"
});
```