### PR TITLE
fixed this not refering to window at call time.

### DIFF
--- a/sharepointplus-5.0.js
+++ b/sharepointplus-5.0.js
@@ -4979,4 +4979,4 @@ var _SP_JSON_ACCEPT="verbose"; // other options are "minimalmetadata" and "nomet
   }
 
   return SharepointPlus;
-})(this,(typeof document!=="undefined"?document:null));
+})(window || this,(typeof document!=="undefined"?document:null));


### PR DESCRIPTION
When using sharepointplus as a webpack module, `this` does not refer to `window` object when calling the main function at line 4982. This results in errors like `cannot read property href of undefined` when refering to `window.location.href` as `window` now points to the module itself.